### PR TITLE
Fix Teams Message not being sent

### DIFF
--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
@@ -102,6 +102,26 @@ In this task, you will update the new playbook you created with the proper conne
 
 16. Select **Save** on the command bar.
 
+17. We are now going to grant permissions to the Playbook Logic App to enable retrieval of information about incidents. In the Search bar of the Azure portal, type *Log Analytics*, then select **Log Analytics workspaces**.
+
+18. Select the workspace you created for Sentinel..
+
+19. Select the **Access control (IAM)** on the left menu, then select the **Role assignments** tab.
+
+20. Select **Add** in the top bar menu and then **Add role assignment**.
+
+21. Type *Contributor* in the search field and select the **Contributor** role. Then click the **Next** button at the bottom of the page.
+
+22. In the *Assign access to* field, select **Managed identity**.
+
+23. In *Members*, click on **Select members**.
+
+24. In the blade that appears, in *Managed identity*, choose **Logic app**.
+
+25. Select the *PostMessageTeams-OnAlert* identity and then click on the *Select* button.
+
+26. Click on *Next* and then *Review + Assign*.
+
 The Logic App will be used in a future lab.
 
 ## Proceed to Exercise 3

--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
@@ -104,7 +104,7 @@ In this task, you will update the new playbook you created with the proper conne
 
 17. We are now going to grant permissions to the Playbook Logic App to enable retrieval of information about incidents. In the Search bar of the Azure portal, type *Log Analytics*, then select **Log Analytics workspaces**.
 
-18. Select the workspace you created for Sentinel..
+18. Select the workspace you created for Sentinel.
 
 19. Select the **Access control (IAM)** on the left menu, then select the **Role assignments** tab.
 
@@ -118,9 +118,9 @@ In this task, you will update the new playbook you created with the proper conne
 
 24. In the blade that appears, in *Managed identity*, choose **Logic app**.
 
-25. Select the *PostMessageTeams-OnAlert* identity and then click on the *Select* button.
+25. Select the **PostMessageTeams-OnAlert** identity and then click on the **Select** button.
 
-26. Click on *Next* and then *Review + Assign*.
+26. Click on **Next** and then **Review + Assign**.
 
 The Logic App will be used in a future lab.
 


### PR DESCRIPTION
Permissions need to be granted to the LogicApp's managed identity so that a permissions error is not thrown in the LogicApp when an incident is created.
Otherwise, the LogicApp will not have sufficient permissions to retrieve details about the incident in Sentinel and the message to Teams will not be sent.

# Module: 07
## Lab/Demo: 1 - Exercise 2

Changes proposed in this pull request:

- Grant permissions to playbook's managed identity in Log Analytics Workspace to avoid errors when retrieving incident information.
- Fix error when sending message to Teams channel