### PR TITLE
Fix issue M07-LAB01-Ex02: Playbook is gone #112

### DIFF
--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
@@ -64,7 +64,9 @@ In this task, you will create a Logic App that will be used as a Playbook in Mic
 
 1. On the right pane, select the **Onboard community content** link. This will open a new tab in the Edge Browser for Microsoft Sentinel GitHub content.
 
-1. Select the **Playbooks** folder.
+1. Select the **Solutions** folder.
+
+1. Next select the **Teams** folder, then the **Playbooks** folder.
 
 1. Select the **Post-Message-Teams** folder.
 


### PR DESCRIPTION
**M07-LAB01-Ex02: Playbook is gone #112**

## M07-LAB01-Ex02: Playbook is gone #112

**Link related Github Issue** 🢂 Fixes #112 

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 M07-LAB01-Ex02: Playbook is gone #112📝
- [x] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Added instructions to new folder in GitHUb - https://github.com/Azure/Azure-Sentinel/tree/master/Solutions/Teams/Playbooks/Post-Message-Teams
-
-
