### PR TITLE
Minor changes due to portal changes and a change regarding host switch visibility

### DIFF
--- a/Instructions/Labs/LAB_AK_02_Lab1_Ex1_Deploy_Defender_Endpoint.md
+++ b/Instructions/Labs/LAB_AK_02_Lab1_Ex1_Deploy_Defender_Endpoint.md
@@ -23,7 +23,7 @@ You start by initializing the Defender for Endpoint environment. Next, you onboa
 
 In this task, you will perform the initialization of the Microsoft Defender for Endpoint portal.
 
-1. Log in to WIN1 virtual machine as Admin with the password: **Pa55w.rd**.  
+1. Log in to **WIN1** virtual machine as Admin with the password: **Pa55w.rd**.  
 
 1. If you are not already at the Microsoft 365 Defender portal, start the Microsoft Edge browser.
 
@@ -72,7 +72,7 @@ In this task, you will onboard a device to Microsoft Defender for Endpoint using
 
 1. Paste the script by right-clicking in the **Administrator: Command Prompt** windows and press **Enter** to run it. **Note:** The window closes automatically after running the script.
 
-1. In the Microsoft 365 Defender portal, in the left-hand menu, under the Endpoints area, select **Device inventory**. If the device is not shown, complete the next task and come back to check it back later. It can take up to 60 minutes for the first device to be displayed in the portal.
+1. In the Microsoft 365 Defender portal, in the left-hand menu, under the **Assets** area, select **Devices**. If the device is not shown, complete the next task and come back to check it back later. It can take up to 60 minutes for the first device to be displayed in the portal.
 
     >**Note:** If you have completed the onboarding process and don't see devices in the Devices list after an hour, it might indicate an onboarding or connectivity problem.
 

--- a/Instructions/Labs/LAB_AK_03_Lab1_Ex1_Enable_Defender.md
+++ b/Instructions/Labs/LAB_AK_03_Lab1_Ex1_Enable_Defender.md
@@ -17,7 +17,7 @@ You are a Security Operations Analyst working at a company that is implementing 
 
 In this task, you will set up an Azure Subscription required to complete this lab and future labs.
 
-1. Log in to WIN1 virtual machine as Admin with the password: **Pa55w.rd**.  
+1. Log in to **WIN1** virtual machine as Admin with the password: **Pa55w.rd**.  
 
 1. Open the Microsoft Edge browser or open a new tab if already open.
 
@@ -86,7 +86,7 @@ In this task, you will install Azure Arc on an on-premises server to make onboar
 
 >**Important:** The next steps are done in a different machine than the one you were previously working. Look for the Virtual Machine name references.
 
-1. Log in to WINServer virtual machine as Administrator with the password: **Passw0rd!** if required.  
+1. Log in to **WINServer** virtual machine as Administrator with the password: **Passw0rd!** if required.  
 
 1. Open the Microsoft Edge browser and navigate to the Azure portal at https://portal.azure.com.
 
@@ -151,7 +151,7 @@ In this task, you will install Azure Arc on an on-premises server to make onboar
 
 ### Task 5: Protect an On-Premises Server
 
-In this task, you will manually install the required agent on the WINServer virtual machine.
+In this task, you will manually install the required agent on the **WINServer** virtual machine.
 
 1. Go to **Microsoft Defender for Cloud** and select the **Getting Started** page.
 
@@ -175,7 +175,7 @@ In this task, you will manually install the required agent on the WINServer virt
 
 1. Go to the "Microsoft Defender for Cloud" portal and select **Inventory**.
 
-1. The *WINServer* virtual machine will appear after at least 5 minutes. You may have to select **Refresh** to see it. **Hint:** If you see the number 1 under *Total resources* remove the filter to show the *WINServer* virtual machine.
+1. The **WINServer** virtual machine will appear after at least 5 minutes. You may have to select **Refresh** to see it. **Hint:** If you see the number 1 under *Total resources* remove the filter to show the *WINServer* virtual machine.
 
 1. You can move on to the next lab and return later to review the **Inventory** section of **Microsoft Defender for Cloud**.
 


### PR DESCRIPTION
- M02: Ex1-Task2-Step14: the "Device inventory" does not exist under "Endpoint section in M365D portal. It has moved under "Assets" and renamed to "Devices"

- M03: Ex1-Task4-Step1: users bypass the switch to host "WINServer" so I made the change to appear as "bold". Maybe you can consider doing so for other hosts i.e. LIN1.