### PR TITLE
Removed Student Handbook reference link from readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,6 @@
 This repository includes lab instructions for the following courses:
 
 - SC-200T00: Microsoft Security Operations Analyst
- 
-
-**[Download Latest Student Handbook and AllFiles Content](../../releases/latest)**
 
 **Are you a MCT?** - Have a look at our [GitHub User Guide for MCTs](https://microsoftlearning.github.io/MCT-User-Guide/)
 


### PR DESCRIPTION
**The reference link to download the student handbook doesn't work. Handbook is gone.**

## N/A

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Remove link to Download Latest Student Handbook from the readme.md
-
-
