### PR TITLE
KQL Formatting

### DIFF
--- a/Instructions/Labs/LAB_AK_04_Lab1_Ex1_KQL.md
+++ b/Instructions/Labs/LAB_AK_04_Lab1_Ex1_KQL.md
@@ -386,13 +386,15 @@ In this task, you will work with structured and unstructured string fields with 
 1. The following statement demonstrates working with **dynamic** fields, which are special since they can take on any value of other data types. In this example, The DeviceDetail field from the SigninLogs table is of type **dynamic**. In the Query Window enter the following statement and select **Run**: 
 
     ```KQL
-    SigninLogs | extend OS = DeviceDetail.operatingSystem
+    SigninLogs
+    | extend OS = DeviceDetail.operatingSystem
     ```
 
 1. The following example shows how to break out packed fields for SigninLogs. In the Query Window enter the following statement and select **Run**: 
 
     ```KQL
-    SigninLogs | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser 
+    SigninLogs
+    | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser 
     | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails) 
     | extend Date = startofday(TimeGenerated) 
     | summarize count() by Date, Identity, UserDisplayName, UserPrincipalName, IPAddress, ResultType, ResultDescription, StatusCode, StatusDetails 
@@ -404,7 +406,8 @@ In this task, you will work with structured and unstructured string fields with 
 1. The following statements demonstrates operators to manipulate JSON stored in string fields. Many logs submit data in JSON format, which requires you to know how to transform JSON data to fields that can be queried. In the Query Window enter the following statement and select **Run**: 
 
     ```KQL
-    SigninLogs | extend AuthDetails =  todynamic(AuthenticationDetails) 
+    SigninLogs
+    | extend AuthDetails =  todynamic(AuthenticationDetails) 
     | extend AuthMethod =  AuthDetails[0].authenticationMethod 
     | extend AuthResult = AuthDetails[0].["authenticationStepResultDetail"] 
     | project AuthMethod, AuthResult, AuthDetails 
@@ -413,7 +416,8 @@ In this task, you will work with structured and unstructured string fields with 
 1. The following statement demonstrates the **mv-expand** operator, which turns dynamic arrays into rows (multi-value expansion).
 
     ```KQL
-    SigninLogs | mv-expand AuthDetails = todynamic(AuthenticationDetails) 
+    SigninLogs
+    | mv-expand AuthDetails = todynamic(AuthenticationDetails) 
     | project AuthDetails
     ```
 
@@ -422,7 +426,8 @@ In this task, you will work with structured and unstructured string fields with 
 1. The following statement demonstrates the **mv-apply** operator, which applies a subquery to each record and returns the union of the results of all subqueries.
 
     ```KQL
-    SigninLogs | mv-apply AuthDetails = todynamic(AuthenticationDetails) on
+    SigninLogs
+    | mv-apply AuthDetails = todynamic(AuthenticationDetails) on
     (where AuthDetails.authenticationMethod == "Password")
     ```
 

--- a/Instructions/Labs/LAB_AK_05_Lab1_Ex1_Deploy_Sentinel.md
+++ b/Instructions/Labs/LAB_AK_05_Lab1_Ex1_Deploy_Sentinel.md
@@ -128,7 +128,8 @@ In this task, you will create an indicator in Microsoft Sentinel.
 1. Scroll the results to the right to see the DomainName column. You can also run the following KQL statement to just see the DomainName column. 
 
     ```KQL
-    ThreatIntelligenceIndicator | project DomainName
+    ThreatIntelligenceIndicator
+    | project DomainName
     ```
 
 

--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex7_Detections.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex7_Detections.md
@@ -49,7 +49,8 @@ In this task, you will create a detection for the first attack of the previous e
 1. From the results, we now know that the Threat Actor is using reg.exe to add keys to the Registry key and the program is located in C:\temp. **Run** the following statement to replace the *search* operator with the *where* operator in our query:
 
     ```KQL
-    SecurityEvent | where Activity startswith "4688" 
+    SecurityEvent
+    | where Activity startswith "4688" 
     | where Process == "reg.exe" 
     | where CommandLine startswith "REG" 
     ```
@@ -57,7 +58,8 @@ In this task, you will create a detection for the first attack of the previous e
 1. It is important to help the Security Operations Center Analyst by providing as much context about the alert as you can. This includes projecting Entities for use in the investigation graph. **Run** the following query:
 
     ```KQL
-    SecurityEvent | where Activity startswith "4688" 
+    SecurityEvent
+    | where Activity startswith "4688" 
     | where Process == "reg.exe" 
     | where CommandLine startswith "REG" 
     | extend timestamp = TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = SubjectUserName
@@ -110,20 +112,23 @@ In this task, you will create a detection for the second attack of the previous 
 1. **Run** the following KQL Statement to identify any entry that refers to administrators:
 
     ```KQL
-    search "administrators" | summarize count() by $table
+    search "administrators"
+    | summarize count() by $table
     ```
 
 1. The result might show events from different tables, but in our case, we want to investigate the SecurityEvent table. The EventID and Event that we are looking is "4732 - A member was added to a security-enabled local group". With this, we will identify adding a member to a privileged group. **Run** the following KQL query to confirm:
 
     ```KQL
-    SecurityEvent | where EventID == 4732
+    SecurityEvent
+    | where EventID == 4732
     | where TargetAccount == "Builtin\\Administrators"
     ```
 
 1. Expand the row to see all the columns related to the record. The username of the account added as Administrator does not show. The issue is that instead of storing the username, we have the Security IDentifier (SID). **Run** the following KQL to match the SID to the username that was added to the Administrators group:
 
     ```KQL
-    SecurityEvent | where EventID == 4732
+    SecurityEvent
+    | where EventID == 4732
     | where TargetAccount == "Builtin\\Administrators"
     | extend Acct = MemberSid, MachId = SourceComputerId  
     | join kind=leftouter (
@@ -137,7 +142,8 @@ In this task, you will create a detection for the second attack of the previous 
 1. Extend the row to show the resulting columns, in the last one, we see the name of the added user under the *UserName1* column we *project* within the KQL query. It is important to help the Security Operations Analyst by providing as much context about the alert as you can. This includes projecting Entities for use in the investigation graph. **Run** the following query:
 
     ```KQL
-    SecurityEvent | where EventID == 4732
+    SecurityEvent
+    | where EventID == 4732
     | where TargetAccount == "Builtin\\Administrators"
     | extend Acct = MemberSid, MachId = SourceComputerId  
     | join kind=leftouter (

--- a/Instructions/Labs/LAB_AK_08_Lab1_Ex1_Hunting.md
+++ b/Instructions/Labs/LAB_AK_08_Lab1_Ex1_Hunting.md
@@ -43,7 +43,8 @@ In this task, you will create a hunting query, bookmark a result, and create a L
 
     ```KQL
     let lookback = 2d; 
-    SecurityEvent | where TimeGenerated >= ago(lookback) 
+    SecurityEvent
+    | where TimeGenerated >= ago(lookback) 
     | where EventID == 4688 and Process =~ "powershell.exe"
     | extend PwshParam = trim(@"[^/\\]*powershell(.exe)+" , CommandLine) 
     | project TimeGenerated, Computer, SubjectUserName, PwshParam 
@@ -77,7 +78,8 @@ In this task, you will create a hunting query, bookmark a result, and create a L
 
     ```KQL
     let lookback = 2d; 
-    SecurityEvent | where TimeGenerated >= ago(lookback) 
+    SecurityEvent
+    | where TimeGenerated >= ago(lookback) 
     | where EventID == 4688 and Process =~ "powershell.exe"
     | extend PwshParam = trim(@"[^/\\]*powershell(.exe)+" , CommandLine) 
     | project TimeGenerated, Computer, SubjectUserName, PwshParam 
@@ -149,7 +151,8 @@ In this task, instead of using a LiveStream, you will create a NRT analytics que
 
     ```KQL
     let lookback = 2d; 
-    SecurityEvent | where TimeGenerated >= ago(lookback) 
+    SecurityEvent
+    | where TimeGenerated >= ago(lookback) 
     | where EventID == 4688 and Process =~ "powershell.exe"
     | extend PwshParam = trim(@"[^/\\]*powershell(.exe)+" , CommandLine) 
     | project TimeGenerated, Computer, SubjectUserName, PwshParam 

--- a/Instructions/Labs/LAB_AK_08_Lab1_Ex2_Notebooks.md
+++ b/Instructions/Labs/LAB_AK_08_Lab1_Ex2_Notebooks.md
@@ -69,7 +69,7 @@ In this task, you will explore using notebooks in Microsoft Sentinel.
 
 1. Type a unique name in the *Compute name* field. This will identify you compute instance.
 
-1. Under *Virtual machine size*, select the least expensive recommended option.
+1. Under *Virtual machine size* select the first option available. **Hint:** *Workload type*: Development on Notebooks (or other IDE) and light weight testing.
 
 1. Select the **Create** button at the bottom of the screen. Close any feedback window that may appear. This will take a few minutes, you will see a notification (bell icon) when it is done and the *Compute instance* left icon turns from blue to green.
 

--- a/Instructions/Labs/LAB_AK_08_Lab1_Ex2_Notebooks.md
+++ b/Instructions/Labs/LAB_AK_08_Lab1_Ex2_Notebooks.md
@@ -69,7 +69,7 @@ In this task, you will explore using notebooks in Microsoft Sentinel.
 
 1. Type a unique name in the *Compute name* field. This will identify you compute instance.
 
-1. Scroll down and select the first option available. **Hint:** Workload type: Development on Notebooks and light weight testing.
+1. Under *Virtual machine size*, select the least expensive recommended option.
 
 1. Select the **Create** button at the bottom of the screen. Close any feedback window that may appear. This will take a few minutes, you will see a notification (bell icon) when it is done and the *Compute instance* left icon turns from blue to green.
 


### PR DESCRIPTION
**Various Labs: Corrected KQL formatting to match documentation**

## Related Issue

**Link related Github Issue** 🢂 Fixes #186 . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Some (but not all) KQL statements in the labs have the TableName followed by a pipe (instead of having the pipe on the next line.) This works, but the technique is not used in the documentation. Just changing for consistency. (Feel free to ignore.)
