### PR TITLE
Resolving Playbook name discrepancy issue #209

### DIFF
--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex2_Playbook.md
@@ -52,7 +52,9 @@ In this task, you'll create a Microsoft Teams team for use in the lab.
 
 In this task, you'll create a Logic App that is used as a Playbook in Microsoft Sentinel.
 
-1. In the Microsoft Edge browser, navigate to the Azure portal at https://portal.azure.com.
+1. In the Microsoft Edge browser, navigate to [Microsoft Sentinel on GitHub](https://github.com/Azure/Azure-Sentinel).
+
+<!--- the Azure portal at https://portal.azure.com.
 
 1. In the **Sign in** dialog box, copy and paste in the **Tenant Email** account provided by your lab hosting provider and then select **Next**.
 
@@ -64,9 +66,9 @@ In this task, you'll create a Logic App that is used as a Playbook in Microsoft 
 
 1. Select the **Community** page under the *Content management* area on the left side of the page.
 
-1. On the right pane, select the **Onboard community content** link. This opens a new tab in the Microsoft Edge Browser for Microsoft Sentinel GitHub content. **Hint:** You might need to scroll right to see the link. Alternatively, follow this link instead: [Microsoft Sentinel on GitHub](https://github.com/Azure/Azure-Sentinel).
+1. On the right pane, select the **Onboard community content** link. This opens a new tab in the Microsoft Edge Browser for Microsoft Sentinel GitHub content. **Hint:** You might need to scroll right to see the link. Alternatively, follow this link instead: [Microsoft Sentinel on GitHub](https://github.com/Azure/Azure-Sentinel). --->
 
-1. Select the **Solutions** folder.
+1. Scroll down and select the **Solutions** folder.
 
 1. Next select the **SentinelSOARessentials** folder, then the **Playbooks** folder.
 
@@ -98,7 +100,7 @@ In this task, you'll update the new playbook you created with the proper connect
 
 1. Select **Refresh** from the command bar in case you don't see any playbooks. You should see the playbook created from the previous step with the **Microsoft Sentinel Incident** *Trigger kind*.
 
-1. Select the **PostMessageTeams** playbook name.
+1. Select the **PostMessageTeams-OnIncident** playbook name.
 
 1. On the Logic App page for *PostMessageTeams*, in the command menu, select **Edit**.
 

--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex3_Scheduled_Query.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex3_Scheduled_Query.md
@@ -86,7 +86,7 @@ In this task, you'll create a scheduled query and connect it to the Teams channe
 
 1. On the *Manage Permissions* page, select the **RG-Playbooks** resource group you created in the previous lab, and select **Apply**.
 
-1. From the drop-down menu, select the playbook **PostMessageTeams-OnAlert** you created in the previous exercise.
+1. From the drop-down menu, select the playbook **PostMessageTeams-OnIncident** you created in the previous exercise.
 
 1. Select **Apply**
 


### PR DESCRIPTION
**Resolves issue #209**

## Related Issue

**Link related Github Issue** 🢂 Fixes #209  . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Changed Playbook to PostMessageTeams-OnIncident
- Added direct link to GitHub Playbook deployment as Sentinel UI changed
-
