### PR TITLE
M07-Lab01-Ex7: Playbook name correction

### DIFF
--- a/Instructions/Labs/LAB_AK_07_Lab1_Ex7_Detections.md
+++ b/Instructions/Labs/LAB_AK_07_Lab1_Ex7_Detections.md
@@ -208,7 +208,7 @@ In this task, you will create a detection for the second attack of the previous 
    |Automation rule name|SecurityEvent Local Administrators User Add|
    |Trigger|When incident is created|
    |Actions |Run playbook|
-   |playbook |PostMessageTeams-OnAlert|
+   |playbook |PostMessageTeams-OnIncident|
 
    >**Note:** You have already assigned permissions to the playbook, so it will be available.
 


### PR DESCRIPTION
Playbook name was previously changed to "**PostMessageTeams-OnIncident**"

**MOD 07-Lab01-Ex07, Task02, Step14**

## Related Issue

**Link related Github Issue** 🢂 Fixes #209  . 

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- In previous PRs, the playbook was renamed to PostMessageTeams-OnIncident and the name was updated, but this one reference was missed
