### PR TITLE
Resolve bug - Owner role assignment might differ in Conditions tab #234

### DIFF
--- a/Instructions/Labs/LAB_AK_03_Lab1_Ex1_Enable_Defender.md
+++ b/Instructions/Labs/LAB_AK_03_Lab1_Ex1_Enable_Defender.md
@@ -41,7 +41,7 @@ In this task, you'll set up an Azure Subscription required to complete this lab 
 
 1. Under the *Members* tab, select **+ Select members** and select the **MOD Administrator** account and select **Select** to continue.
 
-    >**Note:** If you see the **Conditions** tab (with a red dot), select **Next**, and then select **Not constrained** from the *Delegation type.
+    >**Note:** If the **Conditions** tab displays a red dot, select **Next**, and either select **Not constrained** if presented with the *Delegation* type, or select **Allow user to assign all roles (highly privileged)** if presented with *What user can do*.
 
 1. Select **Review + assign** twice to assign the owner role to your admin account.
 


### PR DESCRIPTION
**Owner role assignment might differ in Conditions**

## Related Issue

**Link related Github Issue** 🢂 Fixes #234 . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- modified note
-
-
