### PR TITLE
Add azcmagent installation steps for LIN2

### DIFF
--- a/Instructions/Labs/LAB_AK_08_Lab1_Ex03_Connect_Linux.md
+++ b/Instructions/Labs/LAB_AK_08_Lab1_Ex03_Connect_Linux.md
@@ -64,6 +64,14 @@ In this task, you will connect a Linux host to Microsoft Sentinel with the Commo
 
     ![linux login](../Media/PSconnectLinux.png)
 
+
+1. In the SSH session, at the linux prompt, type the following command to install azcmagent on LIN2.
+   ```cmd
+    wget https://aka.ms/azcmagent -O ~/Install_linux_azcmagent.sh
+    bash ~/Install_linux_azcmagent.sh
+   ```
+
+
 1. In the SSH session, at the linux prompt, type the following command. *Do not press enter*:
 
     ```cmd


### PR DESCRIPTION
Added instructions to install azcmagent on LIN2 via SSH.

LIN2 image does not have arc agent intall command on it, it needs to be wget installed from the shell script first before you can continue to rest of the lab 

MS Learn ref : https://learn.microsoft.com/en-us/azure/azure-arc/servers/onboard-portal

**Replace issue name M00-LAB00:QUICK_DESCRIPTION, for example "M01-LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related Github Issue** 🢂 Fixes # . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

-
-
-
