### PR TITLE
Fix references to LIN1 and LIN2 in lab instructions

### DIFF
--- a/Instructions/Labs/LAB_AK_08_Lab1_Ex03_Connect_Linux.md
+++ b/Instructions/Labs/LAB_AK_08_Lab1_Ex03_Connect_Linux.md
@@ -144,11 +144,11 @@ In this task, you will connect a Linux host to Microsoft Sentinel with the Commo
 
 1. Next, in the Configuration* section, copy the script to install the AMA Forwarder by using the "Copy to clipboard" icon.
 
-1. Return to the *PowerShell Command Prompt* window. You should still be connected to the LIN2 virtual machine.
+1. Return to the *PowerShell Command Prompt* window. You should still be connected to the LIN1 virtual machine.
 
 1. At the linux prompt, paste the AMA Forwarder installation script you copied in the previous step.
 
-1. You will need to edit the script for the correct *Python* version installed on your LIN2 machine.
+1. You will need to edit the script for the correct *Python* version installed on your LIN1 machine.
 
 1. Change the script section that contains the *python Forwarder_AMA_installer.py* commands to *python3 Forwarder_AMA_installer.py*.
 
@@ -288,6 +288,6 @@ In this task, you will connect a Linux host to Microsoft Sentinel with the Syslo
 
     >**Note:** You can query the *Syslog* table for Syslog events.
 
-1. Type **exit** to close the remote shell connection to LIN1.
+1. Type **exit** to close the remote shell connection to LIN2.
 
 ## Proceed to Exercise 4


### PR DESCRIPTION
LIN 1 is in Task 1 & 2, LIN2 is in Task 3

**Replace issue name M00-LAB00:QUICK_DESCRIPTION, for example "M01-LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related GitHub Issue** 🢂 Fixes #481. (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Changed two incorrect references to LIN2 in Task 2
- Changed one incorrect reference to LIN1 in Task 3
