### PR TITLE
Fix whitespace in KQL lab

### DIFF
--- a/Instructions/Labs/LAB_AK_05_Lab1_Ex01_KQL_Defender.md
+++ b/Instructions/Labs/LAB_AK_05_Lab1_Ex01_KQL_Defender.md
@@ -382,9 +382,9 @@ In this task, you'll work with structured and unstructured string fields with KQ
     (where AuthDetails.authenticationMethod == "Password")
     ```
 
-A **function** is a log query that can be used in other log queries with the saved name as a command. 
+A **function** is a log query that can be used in other log queries with the saved name as a command.
 
-1. To create a **function**, after running your query, select the **Save** button and then select **Save As function** from the drop-down. 
+1. To create a **function**, after running your query, select the **Save** button and then select **Save As function** from the drop-down.
 
 1. Enter the name you want (for example: *PrivLogins*) in the **Function name** box.
 
@@ -392,7 +392,7 @@ A **function** is a log query that can be used in other log queries with the sav
 
 1. In the **Location** field select *My functions* or *Shared functions* from the dropdown menu. You can also create a new folder by selecting the **New folder** link.
 
-1. Select **Save**. 
+1. Select **Save**.
 
 1. Expand the *side panel* if collapsed, and use the drop down to select *Functions* and then select the folder under *My functions* or *Shared functions* where you saved your function. You should see the function you just created.
 


### PR DESCRIPTION
Removes three trailing spaces surfaced by post-merge validation of #563.