### PR TITLE
Learning Path 09 - Lab 1 - Exercise 1: This PR addresses multiple issues identified.

### DIFF
--- a/Instructions/Labs/LAB_AK_09_Lab1_Ex01_Hunting_Defender.md
+++ b/Instructions/Labs/LAB_AK_09_Lab1_Ex01_Hunting_Defender.md
@@ -1,6 +1,6 @@
 ---
 lab:
-    title: Exercise 1 - Perform Threat Hunting with Microsoft Sentinel in Microsoft Defender XDR
+  title: Exercise 1 - Perform Threat Hunting with Microsoft Sentinel in Microsoft Defender XDR
   module: Learning Path 9 - Perform threat hunting in Microsoft Sentinel
   description: The log data created in the Learning Path 9 lab exercises will not be available in this lab without rerunning the following prerequisite tasks.
   duration: 60 minutes
@@ -213,8 +213,6 @@ In this task, you'll create a hunting query, and create a Livestream.
 
    >**Important:** Please paste any KQL queries first in Notepad and then copy from there to the *New query* tab to avoid any errors.
 
-   >**Note:** If you receive the message, "security.microsoft.com wants to.. See text and images copied to the clipboard", select **Allow**.
-
     ```KQL
     let lookback = 2d; 
     SecurityEvent
@@ -269,11 +267,13 @@ In this task, you'll create a hunting query, and create a Livestream.
 
 1. Expand the **Hunting** section and select **Advanced hunting**.
 
-1. Select the **Create new graph** icon, or the *New graph* tab.
+1. In **Advanced hunting**, select the **+** button next to **New query**.
+
+1. From the menu, select **Hunting graph**.
 
 1. Select **Search with Predefined scenarios**.
 
-1. On the **Search Predefined scenarios** pane, select the **Users with access to Sensitive data** Scenario.
+1. On the **Select a scenarios** pane, select the **Users with access to Sensitive data** Scenario.
 
 1. In the *Scenario inputs*, enter **sensitivestorageaccount** for the *Target storage account*.
 
@@ -454,7 +454,7 @@ In this task, you'll create a Data lake KQL job to look for a C2 attack.
 
     >**Note:** The *_KQL_CL* is the custom log default appendix.
 
-1. Leave the *Create a new table* radio button selected, and enter **C2ATTACKHUNT** for the new table name.
+1. Leave the *Create a new table* radio button selected, and enter **C2ATTACKHUNT_XXX** (replace XXX with your initials or a unique value) for the new table name.
 
 1. Select the **Next** button.
 
@@ -490,9 +490,9 @@ In this task, you'll create a Data lake KQL job to look for a C2 attack.
 
 1. You can view the history of the job runs and other details.
 
-1. Select the *Destination table* link for **C2ATTACKHUNT_KQL_CL**.
+1. Select the *Destination table* link for **C2ATTACKHUNT_XXX_KQL_CL**.
 
-1. This opens the **Advanced hunting** page with the **C2ATTACKHUNT_KQL_CL** table populated in the *New query* form. If the table name has a red rippled underline, it means the table is unknown and it may take several minutes to be updated.
+1. This opens the **Advanced hunting** page with the **C2ATTACKHUNT_XXX_KQL_CL** table populated in the *New query* form. If the table name has a red rippled underline, it means the table is unknown and it may take several minutes to be updated.
 
     >**Note:** After the table is known to *Advanced hunting*, you can modify the query as needed to refine your search.
 

--- a/Instructions/Labs/LAB_AK_09_Lab1_Ex01_Hunting_Defender.md
+++ b/Instructions/Labs/LAB_AK_09_Lab1_Ex01_Hunting_Defender.md
@@ -273,7 +273,7 @@ In this task, you'll create a hunting query, and create a Livestream.
 
 1. Select **Search with Predefined scenarios**.
 
-1. On the **Select a scenarios** pane, select the **Users with access to Sensitive data** Scenario.
+1. On the **Select a scenario** pane, select the **Users with access to Sensitive data** Scenario.
 
 1. In the *Scenario inputs*, enter **sensitivestorageaccount** for the *Target storage account*.
 


### PR DESCRIPTION
## Learning Path 09 - Lab 1 - Exercise 1

### PR Details

This PR addresses multiple issues identified while testing Learning Path 09 - Lab 1.

### Changes Included

#### Updated Advanced Hunting graph instructions
- Updated instructions to match the current UI experience.
- Replaced references to **Create new graph** and **New graph**.
- Updated workflow to:
  1. Select the **+** button next to **New query**.
  2. Select **Hunting graph**.

#### Fixed formatting issues
- Corrected lab title and content formatting inconsistencies.
- Improved readability of affected instructions.

#### Updated destination table instructions
- Replaced the fixed table name **C2ATTACKHUNT** with a unique table name format to prevent conflicts in shared lab environments.
- Updated subsequent steps to reference the learner-created destination table instead of a hard-coded table name.

### Validation

- Verified the current UI no longer contains the **Create new graph** icon or **New graph** tab.
- Confirmed that using **C2ATTACKHUNT** can result in a **Table name already exists** validation error in a shared environment.
- Verified that using a unique table name allows the exercise to be completed successfully.

### Related Issue

Fixes #538

### Screenshots

- Lab title formatting issue
- UI

### Screenshots:

<img width="2231" height="1117" alt="image" src="https://github.com/user-attachments/assets/1e7097b4-cbd6-42ba-a025-536cc6a0b0ff" />

Lab title issue:
<img width="1726" height="995" alt="image" src="https://github.com/user-attachments/assets/033a8b24-bf00-42fa-8e7f-c1f170715102" />

UI updates:
<img width="1358" height="1129" alt="image" src="https://github.com/user-attachments/assets/6930f3d2-5f84-4eda-b33b-db00f38c1162" />

Reported issue screenshot: 
<img width="2171" height="1168" alt="image" src="https://github.com/user-attachments/assets/76f7671b-86f6-4531-8d22-731a7112b1c8" />



