### PR TITLE
Learning Path 5 - Lab 1 - Exercise 1 - Refactor KQL queries and enhance instruction clarity

### DIFF
--- a/Instructions/Labs/LAB_AK_05_Lab1_Ex01_KQL_Defender.md
+++ b/Instructions/Labs/LAB_AK_05_Lab1_Ex01_KQL_Defender.md
@@ -167,7 +167,7 @@ In this task, you'll build KQL statements to aggregate data. **Summarize** group
     ```KQL
     SigninLogs_CL  
     | where TimeGenerated > ago(5d)
-    | summarize dcount(IPAddress_s)
+    | summarize dcount(IPAddress)
     ```
 
 1. The following statement is a rule to detect *User account is disabled* failures across multiple applications for the same account. In the Query Window, enter the following statement and select **Run query**:
@@ -177,8 +177,8 @@ In this task, you'll build KQL statements to aggregate data. **Summarize** group
     let threshold = 1;
     SigninLogs_CL
     | where TimeGenerated >= ago(timeframe)
-    | where ResultDescription_s has "User account is disabled"
-    | summarize applicationCount = dcount(AppDisplayName_s) by UserPrincipalName_s, IPAddress_s
+    | where ResultDescription has "User account is disabled"
+    | summarize applicationCount = dcount(AppDisplayName_s) by UserPrincipalName_s, IPAddress
     | where applicationCount >= threshold
     ```
 
@@ -262,9 +262,7 @@ In this task, you'll generate visualizations with KQL statements.
 
 In this task, you'll build multi-table KQL statements.
 
-1. Change the **Time range** to **Custom time range** in the *Query* window spanning at least 5 days for the following statements.
-
-1. The following statement demonstrates the **union** operator, which takes two or more tables and returns all their rows. Understanding how results are passed and impacted with the pipe character is essential. In the Query Window, enter the following statements and select **Run query** for each query separately to see the results:
+1. The following statements demonstrate the **union** operator, which takes two or more tables and returns all their rows. Understanding how results are passed and impacted with the pipe character is essential. Before running the following queries, change the **Time range** to **Custom time range** in the *Query* window, spanning at least 5 days. In the Query Window, enter the following statements and select **Run query** for each query separately to see the results:
 
     1. **Query 1** returns all rows of SecurityEvent_CL and all rows of SigninLogs_CL.
 


### PR DESCRIPTION
## Learning Path 5 - Lab 1 - Exercise 1 - Create queries for Microsoft Sentinel using Kusto Query Language (KQL)

Updated KQL queries to use 'IPAddress' instead of 'IPAddress_s' and 'ResultDescription' instead of 'ResultDescription_s' for consistency. Modified instructions for clarity regarding the time range setting.

**Replace issue name M00-LAB00:QUICK_DESCRIPTION, for example "M01-LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related Github Issue** 🢂 Fixes #575. (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Updated KQL queries to use 'IPAddress' instead of 'IPAddress_s'
- Updated KQL queries to use 'ResultDescription' instead of 'ResultDescription_s'
- Modified instructions for clarity regarding the time range setting


### Screenshots

<img width="1091" height="673" alt="image" src="https://github.com/user-attachments/assets/fe185da5-9cb3-4260-b7c3-1ace6f8ed4da" />
<img width="1213" height="725" alt="image" src="https://github.com/user-attachments/assets/98cf56f8-a24a-4a77-ac0d-2bafe562c17e" />

<img width="2273" height="802" alt="image" src="https://github.com/user-attachments/assets/0b7f2ca0-9474-4a94-ad5e-74e5e22341b2" />

<img width="2212" height="796" alt="image" src="https://github.com/user-attachments/assets/e7546d4a-be31-4882-a71f-8b7666916458" />

